### PR TITLE
update middle node balance as max value

### DIFF
--- a/csv/entry_4.csv
+++ b/csv/entry_4.csv
@@ -1,0 +1,5 @@
+username,balance_ETH_ETH,balance_USDT_ETH
+dxGaEAii,11888,41163
+MBlfbBGI,67823,18651
+lAhWlEWZ,18651,2087
+nuZweYtO,22073,55683

--- a/zk_prover/examples/commitment_solidity_calldata.json
+++ b/zk_prover/examples/commitment_solidity_calldata.json
@@ -1,7 +1,7 @@
 {
-  "root_hash": "0x18d6ab953235a811edffa4cead74ea045e7cd2085771a2269d59dca054c955b1",
+  "root_hash": "0x1bdf7b5ef2bb623ffad81eb69f5d5bee02f29c9342e54e755c459d450c4a4a99",
   "root_balances": [
-    "0x87f3e",
-    "0x87f3e"
+    "0x14560",
+    "0x14560"
   ]
 }

--- a/zk_prover/examples/gen_commitment.rs
+++ b/zk_prover/examples/gen_commitment.rs
@@ -14,7 +14,7 @@ const N_BYTES: usize = 8;
 fn main() {
     let merkle_sum_tree =
         MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
-
+    println!("{:?}", merkle_sum_tree);
     let root = merkle_sum_tree.root();
 
     // The commitment to be published on-chain is made of (root_hash, root_balances)

--- a/zk_prover/src/merkle_sum_tree/mst.rs
+++ b/zk_prover/src/merkle_sum_tree/mst.rs
@@ -192,7 +192,13 @@ impl<const N_CURRENCIES: usize, const N_BYTES: usize> MerkleSumTree<N_CURRENCIES
 
             let mut hash_preimage = [Fp::zero(); N_CURRENCIES + 2];
             for (i, balance) in hash_preimage.iter_mut().enumerate().take(N_CURRENCIES) {
-                *balance = left_child.balances[i] + right_child.balances[i];
+                // compare right_child.balances[i] with left_child.balances[i]
+                // set balance as maximum of the two
+                if right_child.balances[i] > left_child.balances[i] {
+                    *balance = right_child.balances[i];
+                } else {
+                    *balance = left_child.balances[i];
+                }
             }
             hash_preimage[N_CURRENCIES] = left_child.hash;
             hash_preimage[N_CURRENCIES + 1] = right_child.hash;

--- a/zk_prover/src/merkle_sum_tree/node.rs
+++ b/zk_prover/src/merkle_sum_tree/node.rs
@@ -35,7 +35,13 @@ impl<const N_CURRENCIES: usize> Node<N_CURRENCIES> {
     {
         let mut hash_preimage = [Fp::zero(); N_CURRENCIES + 2];
         for (i, balance) in hash_preimage.iter_mut().enumerate().take(N_CURRENCIES) {
-            *balance = child_l.balances[i] + child_r.balances[i];
+            // compare child_l.balances[i] and child_r.balances[i]
+            // and update balance as maximum of the two
+            if child_r.balances[i] > child_l.balances[i] {
+                *balance = child_r.balances[i];
+            } else {
+                *balance = child_l.balances[i];
+            }
         }
         hash_preimage[N_CURRENCIES] = child_l.hash;
         hash_preimage[N_CURRENCIES + 1] = child_r.hash;

--- a/zk_prover/src/merkle_sum_tree/tests.rs
+++ b/zk_prover/src/merkle_sum_tree/tests.rs
@@ -13,17 +13,18 @@ mod test {
     fn test_mst() {
         // create new merkle tree
         let merkle_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
-
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_4.csv").unwrap();
+        println!("merkle_tree: {:?}", merkle_tree);
         // get root
         let root = merkle_tree.root();
+        println!("Root hash: {:?}", root.balances);
 
         // expect root hash to be different than 0
         assert!(root.hash != 0.into());
         // expect balance to match the sum of all entries
-        assert!(root.balances == [556862.into(), 556862.into()]);
-        // expect depth to be 4
-        assert!(*merkle_tree.depth() == 4_usize);
+        assert!(root.balances == [67823.into(), 55683.into()]);
+        // expect depth to be 2
+        assert!(*merkle_tree.depth() == 2_usize);
 
         // get proof for entry 0
         let proof = merkle_tree.generate_proof(0).unwrap();

--- a/zk_prover/src/merkle_sum_tree/utils/build_tree.rs
+++ b/zk_prover/src/merkle_sum_tree/utils/build_tree.rs
@@ -85,8 +85,13 @@ where
             let mut hash_preimage = [Fp::zero(); N_CURRENCIES + 2];
 
             for (i, balance) in hash_preimage.iter_mut().enumerate().take(N_CURRENCIES) {
-                *balance =
-                    tree[level - 1][index].balances[i] + tree[level - 1][index + 1].balances[i];
+                // compare child_l.balances[i] and child_r.balances[i]
+                // and update balance as maximum of the two
+                if tree[level - 1][index + 1].balances[i] > tree[level - 1][index].balances[i] {
+                    *balance = tree[level - 1][index + 1].balances[i];
+                } else {
+                    *balance = tree[level - 1][index].balances[i];
+                }
             }
 
             hash_preimage[N_CURRENCIES] = tree[level - 1][index].hash;


### PR DESCRIPTION
# Overview

As the original Merkle Sum Tree is broken and it has a vulnerability where the custodian can build MerkleTree where the balance of middle nod v can be ` max(vr, vl) <= v <= vr + vl, when vr is a balance of right node, vl is a balance of left node`.  Detail attack factor is described in this [paper](https://eprint.iacr.org/2022/043.pdf).  

 Summa's Merkle tree constructs a middle node that overcomes this vulnerability, trying out simple PoC code. 

Turned out when trying to build a Tree in `max(vr, vl)` this value, and turn out cannot corrupt both balance and hash at the same time when following Summa's Merkle Sum Tree implementation.

# Construct corrupted Merkle Sum Tree

commit: https://github.com/rkdud007/summa-solvency/pull/1/commits/774d68a6d52734831821eba5bd7062505e9a8aa8

<img width="954" alt="Screenshot 2024-03-05 at 6 55 58 PM" src="https://github.com/rkdud007/summa-solvency/assets/76558220/301498cf-2ebf-4971-840a-3579bc0bc0f1">

cargo run --release --example gen_inclusion_proof

```
Start:   Creating params
End:     Creating params ...........................................................16.279ms


Start:   Creating proof
thread 'main' panicked at 'assertion failed: result.is_ok()', /Users/piapark/Documents/GitHub/summa-solvency/zk_prover/src/circuits/utils.rs:193:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

# Corrupt Balance on generating proof

commit: https://github.com/rkdud007/summa-solvency/pull/1/commits/7130a8645675736c86b1cdd54bdd810aea8f98cb

We also want to corrupt proof generation logic, so that non-corrupted Merkle inclusion proof verification should pass with corrupted proof and commit.

As corruption happened in switching the parent node balance into `max(vr, vl)`, the expected corrupted proof should be `max(vr, vl) - current balance` for all `N_CURRUNCIES`.

<img width="661" alt="Screenshot 2024-03-05 at 6 58 28 PM" src="https://github.com/rkdud007/summa-solvency/assets/76558220/3e5b2759-8e1b-462f-8ec8-6cca4651ffce">

# Corrupt Hash on generating proof

As verification checks both balance and hash from proof ( list of path nodes ), we also need to corrupt the hash of this proof. 

As we need to match with corrupted construction's result root node, ( both balance and hash ) 
hash generation should follow the corrupted tree building. 

During construction with maximum value for middle nodes, the middle node's hash is already corrupted with maximum value. But especially in level 1, the child node's hash are same as the original as it is a leaf node.

<img width="577" alt="Screenshot 2024-03-05 at 7 38 03 PM" src="https://github.com/rkdud007/summa-solvency/assets/76558220/00344b55-a5fa-4faf-881b-ff96077abaee">

During proof generation, for example in `Claire` case, start from the sibling leaf node, and all the path node's hash is corrupted not only due to balance but also from the child node hash itself ( as it requires corruption on the leaf node also )

<img width="430" alt="Screenshot 2024-03-05 at 7 39 51 PM" src="https://github.com/rkdud007/summa-solvency/assets/76558220/7573fdee-7653-49b5-964a-9139d539ab8c">

Our goal for exploiting this vulnerability is to match root `0xcorruptedhash` with root `0xcorruptedwithmaximumhash`. As the verification is happening while getting path nodes from proof ( provided leaf and middle node preimages ) and operating summing the balance & hash it within the balance and child hashes, It is impossible to corrupt both balance and hash at the same time. Balance corruption will determine the corrupted hash value, which will not match with `0xcorruptedwithmaximumhash` that cannot be corrupted with proof generation.